### PR TITLE
build: Make shebang universal

### DIFF
--- a/icon-theme/install.sh
+++ b/icon-theme/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 
 ROOT_UID=0
 DEST_DIR=


### PR DESCRIPTION
Just like the GTK theme's install.sh, it makes the icons installation script more portable and universal.