### PR TITLE
Put the paths into quotes to fix issue on path with spaces

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -406,42 +406,42 @@ install_package() {
 }
 
 tweaks_temp() {
-  cp -rf ${SRC_DIR}/sass/_tweaks.scss ${SRC_DIR}/sass/_tweaks-temp.scss
+  cp -rf "${SRC_DIR}/sass/_tweaks.scss" "${SRC_DIR}/sass/_tweaks-temp.scss"
 }
 
 compact_size() {
-  sed -i "/\$compact:/s/false/true/" ${SRC_DIR}/sass/_tweaks-temp.scss
+  sed -i "/\$compact:/s/false/true/" "${SRC_DIR}/sass/_tweaks-temp.scss"
 }
 
 nord_color() {
-  sed -i "/\@import/s/color-palette-default/color-palette-nord/" ${SRC_DIR}/sass/_tweaks-temp.scss
-  sed -i "/\$colorscheme:/s/default/nord/" ${SRC_DIR}/sass/_tweaks-temp.scss
+  sed -i "/\@import/s/color-palette-default/color-palette-nord/" "${SRC_DIR}/sass/_tweaks-temp.scss"
+  sed -i "/\$colorscheme:/s/default/nord/" "${SRC_DIR}/sass/_tweaks-temp.scss"
 }
 
 dracula_color() {
-  sed -i "/\@import/s/color-palette-default/color-palette-dracula/" ${SRC_DIR}/sass/_tweaks-temp.scss
-  sed -i "/\$colorscheme:/s/default/dracula/" ${SRC_DIR}/sass/_tweaks-temp.scss
+  sed -i "/\@import/s/color-palette-default/color-palette-dracula/" "${SRC_DIR}/sass/_tweaks-temp.scss"
+  sed -i "/\$colorscheme:/s/default/dracula/" "${SRC_DIR}/sass/_tweaks-temp.scss"
 }
 
 blackness_color() {
-  sed -i "/\$blackness:/s/false/true/" ${SRC_DIR}/sass/_tweaks-temp.scss
+  sed -i "/\$blackness:/s/false/true/" "${SRC_DIR}/sass/_tweaks-temp.scss"
 }
 
 border_rimless() {
-  sed -i "/\$rimless:/s/false/true/" ${SRC_DIR}/sass/_tweaks-temp.scss
+  sed -i "/\$rimless:/s/false/true/" "${SRC_DIR}/sass/_tweaks-temp.scss"
 }
 
 normal_winbutton() {
-  sed -i "/\$window_button:/s/mac/normal/" ${SRC_DIR}/sass/_tweaks-temp.scss
+  sed -i "/\$window_button:/s/mac/normal/" "${SRC_DIR}/sass/_tweaks-temp.scss"
 }
 
 gnome_shell_version() {
-  cp -rf ${SRC_DIR}/sass/gnome-shell/_common.scss ${SRC_DIR}/sass/gnome-shell/_common-temp.scss
+  cp -rf "${SRC_DIR}/sass/gnome-shell/_common.scss" "${SRC_DIR}/sass/gnome-shell/_common-temp.scss"
 
-  sed -i "/\widgets/s/40-0/${GS_VERSION}/" ${SRC_DIR}/sass/gnome-shell/_common-temp.scss
+  sed -i "/\widgets/s/40-0/${GS_VERSION}/" "${SRC_DIR}/sass/gnome-shell/_common-temp.scss"
 
   if [[ "${GS_VERSION}" == '3-28' ]]; then
-    sed -i "/\extensions/s/40-0/${GS_VERSION}/" ${SRC_DIR}/sass/gnome-shell/_common-temp.scss
+    sed -i "/\extensions/s/40-0/${GS_VERSION}/" "${SRC_DIR}/sass/gnome-shell/_common-temp.scss"
   fi
 }
 
@@ -474,7 +474,7 @@ theme_color() {
         ;;
     esac
     tweaks_temp
-    sed -i "/\$theme:/s/default/${theme_color}/" ${SRC_DIR}/sass/_tweaks-temp.scss
+    sed -i "/\$theme:/s/default/${theme_color}/" "${SRC_DIR}/sass/_tweaks-temp.scss"
   fi
 }
 


### PR DESCRIPTION
Title is self explanatory. I was having issue when trying to install the theme from my cloned repo that has a spaces in its absolute path (something like `/home/ian/Projects/My Themes/Colloid-gtk-theme`). The quotes should fix the issue