### PR TITLE
Fix issues with Amberol playlist (#98)

### DIFF
--- a/src/sass/gtk/apps/_gnome-4.0.scss
+++ b/src/sass/gtk/apps/_gnome-4.0.scss
@@ -1471,6 +1471,24 @@ panelstatusbar {
 }
 
 //
+// Amberol
+//
+
+playlistview {
+  scrollbar {
+    &.overlay-indicator {
+      &.dragging,
+      &.hovering { background-color: transparent; }
+    }
+  }
+
+  queuerow {
+    picture.cover,
+    image.card { border: none; }
+  }
+}
+
+//
 // dialogs
 //
 


### PR DESCRIPTION
This is an attempt to fix #98. Basically I added two CSS rules to `_gnome-4.0.scss`:

1. Background color of overlay scrollbar is set to `transparent` instead of `rgba($surface, 0.9)` defined in `_common-4.0.scss`. This makes the scrollbar look good on any custom background.
2. Border around cover images is removed. Adwaita theme also doesn't have it. See https://gitlab.gnome.org/World/amberol/-/blob/main/src/gtk/style.css#L68 for reference.

These rules are applied to Amberol playlist only. We don't want to enable them globally.