### PR TITLE
Fix GDM password text color

### DIFF
--- a/src/sass/gnome-shell/common/_login-dialog.scss
+++ b/src/sass/gnome-shell/common/_login-dialog.scss
@@ -21,14 +21,14 @@
     padding: 4px 8px;
     min-height: $item_size - $base_padding;
     border-radius: $circular_radius;
-    caret-color: on($primary);
+    caret-color: on($osd);
 
-    @include entry(flat-normal, $tc: on($primary));
-    &:focus { @include entry(flat-focus, $tc: on($primary)); }
-    &:insensitive { @include entry(flat-insensitive, $tc: on($primary, disabled)); }
+    @include entry(flat-normal, $tc: on($osd));
+    &:focus { @include entry(flat-focus, $tc: on($osd)); }
+    &:insensitive { @include entry(flat-insensitive, $tc: on($osd, disabled)); }
 
     StLabel.hint-text {
-      color: on($primary, disabled);
+      color: on($osd, disabled);
     }
   }
 


### PR DESCRIPTION
For variants with a bright `$primary` color, the password entry box in GDM is hard to read. I've tested this with GDM 44.1 and gnome-shell 44.3.

This currently affects `Colloid-Grey-Dark`, `Colloid-Orange-Dark`, `Colloid-Yellow`, `Colloid-Yellow-Dark` and `Colloid-Yellow-Light`.

For example, here is `Colloid-Yellow-Dark` before the patch:
![Empty](https://github.com/vinceliuice/Colloid-gtk-theme/assets/207166/1d2f452b-fd67-4e99-97e3-4669211b5421)
![With password](https://github.com/vinceliuice/Colloid-gtk-theme/assets/207166/c6cc5fb2-34da-45ff-b4d8-440cdef1cd18)

And after:
![Empty](https://github.com/vinceliuice/Colloid-gtk-theme/assets/207166/9edcb29c-57dd-45b0-a3ed-3f3a3fe18f1f)
![With password](https://github.com/vinceliuice/Colloid-gtk-theme/assets/207166/b1e884a6-6a80-458a-965e-3264006a73e0)

The other variants remain unchanged by this commit.