### PR TITLE
Change check for existence of `sassc` as it fails when `which` isn't installed even if `sassc` exists.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -413,7 +413,7 @@ function has_command() {
 
 #  Install needed packages
 install_package() {
-  if [ ! "$(which sassc 2> /dev/null)" ]; then
+  if ! has_command sassc; then
     echo sassc needs to be installed to generate the css.
     if has_command zypper; then
       sudo zypper in sassc


### PR DESCRIPTION
Running `if [ ! "$(which sassc 2> /dev/null)" ];` fails if `which` (on Arch Linux it's not installed by default) is not installed even if `sassc` exists. It is also weird that this is the only check that uses `which` while others use `command -v`.