### PR TITLE
Fix transparent MessageDialogs

### DIFF
--- a/src/sass/gtk/_common-3.0.scss
+++ b/src/sass/gtk/_common-3.0.scss
@@ -3132,15 +3132,11 @@ messagedialog { // Message Dialog styling
       border-bottom-left-radius: $window-radius;
       border-bottom-right-radius: $window-radius;
 
-      @if $variant == 'dark' {
-        background-color: transparent;
-      } @else {
-        background-color: $surface;
-      }
+      background-color: $surface;
 
       .titlebar {
         &, &:backdrop {
-          background-color: if($variant == 'dark', transparent, $surface);
+          background-color: if($variant == 'dark', $base, $surface);
         }
       }
     }


### PR DESCRIPTION
`background-color` was set to `transparent for both the background and titlebar backdrop for message dialogs (csd), resulting in transparent dialog windows.
