### PR TITLE
Fixes #146: Gnome 46 notifications are a mess

### DIFF
--- a/src/sass/gnome-shell/common/_notifications.scss
+++ b/src/sass/gnome-shell/common/_notifications.scss
@@ -8,7 +8,7 @@
   border-radius: $base_radius;
   color: $text-secondary;
   background-color: $popover;
-  border: none;
+  // border: none;
   text-shadow: none;
   box-shadow: 0 3px 5px rgba(0, 0, 0, 0.25);
   border-radius: $menu_radius;


### PR DESCRIPTION
Fixes #146 
```
.notification-banner {
  width: 34em;
  min-height: 64px;
  margin: 12px 5px 8px;
  border-radius: $base_radius;
  color: $text-secondary;
  background-color: $popover;
  // border: none; ------------------------ Commenting this fixes the issue
  text-shadow: none;
  box-shadow: 0 3px 5px rgba(0, 0, 0, 0.25);
  border-radius: $menu_radius;
```