### PR TITLE
Fix notifications for GNOME 46

### DIFF
--- a/src/sass/gnome-shell/common/_calendar.scss
+++ b/src/sass/gnome-shell/common/_calendar.scss
@@ -4,7 +4,6 @@
   color: $text-secondary;
   background-color: $fill;
   border-radius: $base_radius;
-  border: none;
   box-shadow: none;
   text-shadow: none;
 

--- a/src/sass/gnome-shell/common/_notifications.scss
+++ b/src/sass/gnome-shell/common/_notifications.scss
@@ -8,7 +8,6 @@
   border-radius: $base_radius;
   color: $text-secondary;
   background-color: $popover;
-  border: none;
   text-shadow: none;
   box-shadow: 0 3px 5px rgba(0, 0, 0, 0.25);
   border-radius: $menu_radius;


### PR DESCRIPTION
## Summary

In GNOME 46 the notifications are shown incorrectly (as in #146). Other than that, notifications are not shown in the message list.
I found out that the problem is related to the borders; in particular, by removing the line `border:none` (or setting, instead of the property `border`, the property `border-style` to `none`), the notifications are correctly shown.

## Linked Issues
Closes #146.

## Screenshots

![notifications](https://github.com/vinceliuice/Colloid-gtk-theme/assets/15327563/32f86f85-adfe-4b1b-acc6-014edf1bd994)
![message center](https://github.com/vinceliuice/Colloid-gtk-theme/assets/15327563/86059bc8-6c34-4dd5-8396-7f275276722b)
