### PR TITLE
fixes XDG_BASE_DIR support again

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,10 +14,11 @@ DEST_DIR=
 scheme=
 window=
 
-# Destination directory
 if [ "$UID" -eq "$ROOT_UID" ]; then
   DEST_DIR="/usr/share/themes"
-elif [ -n "$HOME/.local/share/themes" ]; then
+elif [ -n "$XDG_DATA_HOME" ]; then
+  DEST_DIR="$XDG_DATA_HOME/themes"
+elif [ -d "$HOME/.local/share/themes" ]; then
   DEST_DIR="$HOME/.local/share/themes"
 else
   DEST_DIR="$HOME/.themes"


### PR DESCRIPTION
If root, install system-wide
If XDG declared, use that
If .local/share/themes exists, use that
Otherwise use ~/.themes


this fixes the bug you introduced and also makes the spec be followed:

```
$XDG_DATA_HOME defines the base directory relative to which user-specific data files should be stored.
If $XDG_DATA_HOME is either not set or empty, a default equal to $HOME/.local/share should be used. 
```
[https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)

fixes #172 

thanks again