### PR TITLE
Update _switcher-popup.scss

### DIFF
--- a/src/sass/gnome-shell/common/_switcher-popup.scss
+++ b/src/sass/gnome-shell/common/_switcher-popup.scss
@@ -13,6 +13,7 @@
     padding: 8px;
     border-radius: $base_radius;
     border: 1px solid transparent;
+    background-color: $panel;
 
     &:outlined {
       background-color: $divider;


### PR DESCRIPTION
Stock GNOME 46:

![image](https://github.com/user-attachments/assets/d2ad4724-d667-420e-b201-e85f6ed269b8)

Colloid Nord (current)

![image](https://github.com/user-attachments/assets/0337579b-1fd5-4b4c-b604-ef8fd99c0cfb)

Colloid Nord (fixed)

![image](https://github.com/user-attachments/assets/2baa579d-ea6b-4d45-bc3d-df4a6720278a)
