### PR TITLE
chore: create issue template to improve issues structures

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,0 +1,28 @@
+**Describe the bug** A clear and concise description of what the bug is.
+
+**Theme Version** Example: v1.9.0 or latest commit
+
+**Operating System** Example: Ubuntu 22.04, Fedora 39
+
+**Desktop Environment** Example: GNOME 45, KDE Plasma 6.0, XFCE 4.18
+
+**Theme Variant** Example: Colloid-Dark, Colloid-Light, etc.
+
+**Steps to reproduce** Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+**Expected behavior** A clear and concise description of what you expected to
+happen.
+
+**Screenshots** If applicable, add screenshots to help explain your problem.
+
+**Logs** If applicable, add terminal output or system logs.
+
+**Checklist**
+
+- [ ] I checked if the issue already exists.
+- [ ] I provided enough information.


### PR DESCRIPTION
I created a basic issue template to help users report problems with the Colloid GTK Theme more clearly and consistently.
The template asks for essential information like theme version, Linux distribution, desktop environment, steps to reproduce the issue, and screenshots or logs when applicable.

The goal is to improve the overall issue reporting process, making it easier for users to open detailed reports and for maintainers to understand and address issues more efficiently.