### PR TITLE
Add Nixos support via flake.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1785454630,
+        "narHash": "sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH+zRHqg8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1559d3daa3ecc813a650b79375ea61b6741b8746",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "Modern and clean Gtk theme";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+
+      pkgs = import nixpkgs {
+        inherit system;
+      };
+
+    in {
+      packages.${system}.default =
+        pkgs.callPackage ./nix/default.nix {};
+    };
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation {
   pname = "colloid-gtk-theme";
-  version = "3.6.2";
+  version = "nix";
 
   src = ../.;
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, stdenv
+, bash
+, coreutils
+, sassc
+, ...
+}:
+
+stdenv.mkDerivation {
+  pname = "colloid-gtk-theme";
+  version = "3.6.2";
+
+  src = ../.;
+
+  nativeBuildInputs = [
+    bash
+    coreutils
+    sassc
+  ];
+
+  patchPhase = ''
+    patchShebangs install.sh
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    HOME="$TMPDIR" ./install.sh \
+      --dest $out/share/themes
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Colloid GTK Theme";
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
Tested on NixOS unstable with Thunar. The theme builds successfully and is applied correctly through Home Manager.

Note: This currently supports GTK applications only. Libadwaita applications are not supported, as they do not use traditional GTK themes.